### PR TITLE
Fix/Table inserts in topDownTableOrder

### DIFF
--- a/lib/generate-script-statements/add-insert-statements.js
+++ b/lib/generate-script-statements/add-insert-statements.js
@@ -1,16 +1,24 @@
-'use strict'
+"use strict";
 
-const _ = require('lodash')
+const _ = require("lodash");
 
-module.exports = function addInsertStatements (scriptStatements, fileInfo, options) {
-  if (Object.prototype.hasOwnProperty.call(fileInfo, 'inserts')) {
-    _.forOwn(
-      fileInfo.inserts,
-      function (info, filePath) {
-        scriptStatements.push(
-          `COPY ${_.snakeCase(options.schemaName)}.${_.snakeCase(info.tableName)}(${info.columnNames.all.join(',')}) FROM '${filePath}' CSV HEADER ${options.sqlQuote};`
-        )
-      }
-    )
+module.exports = function addInsertStatements(scriptStatements, fileInfo, options) {
+  if (!Object.prototype.hasOwnProperty.call(fileInfo, "inserts")) {
+    return;
   }
-}
+
+  const topDownTableOrder = _.isArray(options.topDownTableOrder) ? options.topDownTableOrder : [];
+
+  const inserts = _.map(fileInfo.inserts, (info, filePath) => ({ info, filePath }));
+
+  const sortedInserts = _.sortBy(inserts, (insert) => {
+    const idx = topDownTableOrder.indexOf(insert.info.tableName);
+    return idx >= 0 ? idx : inserts.length;
+  });
+
+  sortedInserts.forEach(({ info, filePath }) =>
+    scriptStatements.push(
+      `COPY ${_.snakeCase(options.schemaName)}.${_.snakeCase(info.tableName)}(${info.columnNames.all.join(",")}) FROM '${filePath}' CSV HEADER ${options.sqlQuote};`,
+    ),
+  );
+};


### PR DESCRIPTION
### Documented on topDownTableOrder and insertion order, is incorrect.
| `topDownTableOrder`   | `[string]` | An array of strings, where each string is a table name. Table inserts will occur in this order and deletes in reverse - use to avoid integrity-constraint errors. If no schema prefix is supplied to a table name, then it's inferred from `schemaName`. 